### PR TITLE
🎨 Set filename outside of PDFJSDev environment check

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3274,19 +3274,21 @@ function webViewerPostMessage(evt) {
       } else {
         ({ action, data } = evt.data);
       }
+      const filename = data.name ? `${data.name}.pdf` : "liker-land_ebook.pdf";
+      const url = `https://liker.land/${filename}`;
       switch (action) {
         case "openBase64File":
           PDFViewerApplication.open({
             data: atob(data.data),
-            originalUrl: data.name,
-            filename: data.name ? `${data.name}.pdf` : "liker-land_ebook.pdf",
+            url,
+            filename,
           });
           break;
         case "openArrayBufferFile":
           PDFViewerApplication.open({
             data: new Uint8Array(data.data),
-            originalUrl: data.name,
-            filename: data.name ? `${data.name}.pdf` : "liker-land_ebook.pdf",
+            url,
+            filename,
           });
           break;
       }


### PR DESCRIPTION
Keep URL to [trigger](https://github.com/likecoin/pdf.js/blob/master/web/app.js#L998C7-L998C25) setting `this.url`

`this.url = arg.originalUrl || arg.url`
`_docFilename = this._contentDispositionFilename || getPdfFilenameFromUrl(this.url);`