### PR TITLE
[TAS-3081] Re-enable light/dark mode, use less aggressive brand color

### DIFF
--- a/web/viewer-geckoview.css
+++ b/web/viewer-geckoview.css
@@ -22,21 +22,21 @@
   --toolbar-icon-opacity: 1;
   --doorhanger-icon-opacity: 0.9;
 
-  --main-color: rgb(249 249 250);
-  --body-bg-color: #235760;
-  --scrollbar-color: rgb(121 121 123);
-  --scrollbar-bg-color: rgb(35 35 39);
-  --field-color: rgb(6 6 6);
-  --field-bg-color: rgb(255 255 255);
-  --field-border-color: rgb(187 187 188);
+  --main-color: rgb(40 100 110);
+  --body-bg-color: rgb(247 247 247);
+  --scrollbar-color: rgb(155 155 155);
+  --scrollbar-bg-color: rgb(215 236 236);
+  --field-color: rgb(40 100 110);
+  --field-bg-color: rgb(247 247 247);
+  --field-border-color: rgb(170 241 231);
   --doorhanger-bg-color: rgb(255 255 255);
   --dialog-button-border: none;
-  --dialog-button-bg-color: rgb(92 92 97);
-  --dialog-button-hover-bg-color: rgb(115 115 115);
+  --dialog-button-bg-color: rgb(12 12 13 / 0.1);
+  --dialog-button-hover-bg-color: rgb(12 12 13 / 0.3);
 
-  --toolbar-bg-color: #28646e;
-  --toolbar-divider-color: rgb(12 12 13);
-  --toolbar-fg-color: #fbfbfe;
+  --toolbar-bg-color: rgb(247 247 247);
+  --toolbar-divider-color: rgb(170 241 231);
+  --toolbar-fg-color: rgb(40 100 110);
   --toolbar-height: 48px;
   --toolbar-border-width: 1px;
 
@@ -45,6 +45,25 @@
 
 :root:dir(rtl) {
   --dir-factor: -1;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --main-color: rgb(170 241 231);
+    --body-bg-color: rgb(40 100 110);
+    --scrollbar-color: rgb(170 241 231);
+    --scrollbar-bg-color: rgb(74 74 74);
+    --field-color: rgb(170 241 231);
+    --field-bg-color: rgb(74 74 74);
+    --field-border-color: rgb(80 227 194);
+    --doorhanger-bg-color: rgb(74 74 79);
+    --dialog-button-bg-color: rgb(92 92 97);
+    --dialog-button-hover-bg-color: rgb(115 115 115);
+
+    --toolbar-bg-color: rgb(74 74 74);
+    --toolbar-divider-color: rgb(155 155 155);
+    --toolbar-fg-color: rgb(170 241 231);
+  }
 }
 
 @media screen and (forced-colors: active) {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -35,54 +35,54 @@
   --doorhanger-icon-opacity: 0.9;
   --doorhanger-height: 8px;
 
-  --main-color: rgb(249 249 250);
-  --body-bg-color: #235760;
-  --progressBar-color: #50e3c2;
-  --progressBar-bg-color: rgb(40 40 43);
-  --progressBar-blend-color: #1aa384;
-  --scrollbar-color: rgb(121 121 123);
-  --scrollbar-bg-color: rgb(35 35 39);
-  --toolbar-icon-bg-color: rgb(255 255 255);
-  --toolbar-icon-hover-bg-color: rgb(255 255 255);
+  --main-color: rgb(40 100 110);
+  --body-bg-color: rgb(247 247 247);
+  --progressBar-color: rgb(80 227 194);
+  --progressBar-bg-color: rgb(215 236 236);
+  --progressBar-blend-color: rgb(170 241 231);
+  --scrollbar-color: rgb(155 155 155);
+  --scrollbar-bg-color: rgb(215 236 236);
+  --toolbar-icon-bg-color: rgb(40 100 110);
+  --toolbar-icon-hover-bg-color: rgb(80 227 194);
 
-  --sidebar-narrow-bg-color: rgb(42 42 46 / 0.9);
-  --sidebar-toolbar-bg-color: #1e4a51;
-  --toolbar-bg-color: #28646e;
-  --toolbar-border-color: rgb(12 12 13);
+  --sidebar-narrow-bg-color: rgb(247, 247, 247 / 0.9);
+  --sidebar-toolbar-bg-color: rgb(215 236 236);
+  --toolbar-bg-color: rgb(247 247 247);
+  --toolbar-border-color: rgb(170 241 231);
   --toolbar-box-shadow: 0 1px 0 var(--toolbar-border-color);
   --toolbar-border-bottom: none;
   --toolbarSidebar-box-shadow: inset calc(-1px * var(--dir-factor)) 0 0
       rgb(0 0 0 / 0.25),
     0 1px 0 rgb(0 0 0 / 0.15), 0 0 1px rgb(0 0 0 / 0.1);
   --toolbarSidebar-border-bottom: none;
-  --button-hover-color: #245b64;
-  --toggled-btn-color: rgb(255 255 255);
+  --button-hover-color: rgb(221 222 223);
+  --toggled-btn-color: rgb(0 0 0);
   --toggled-btn-bg-color: rgb(0 0 0 / 0.3);
   --toggled-hover-active-btn-color: rgb(0 0 0 / 0.4);
   --toggled-hover-btn-outline: none;
-  --dropdown-btn-bg-color: #1e4a51;
+  --dropdown-btn-bg-color: rgb(215 215 219);
   --dropdown-btn-border: none;
   --separator-color: rgb(0 0 0 / 0.3);
   --field-color: rgb(6 6 6);
-  --field-bg-color: #1e4a51;
-  --field-border-color: rgb(115 115 115);
-  --treeitem-color: rgb(255 255 255 / 0.8);
-  --treeitem-bg-color: rgb(255 255 255 / 0.15);
-  --treeitem-hover-color: rgb(255 255 255 / 0.9);
-  --treeitem-selected-color: rgb(255 255 255 / 0.9);
-  --treeitem-selected-bg-color: rgb(255 255 255 / 0.25);
-  --thumbnail-hover-color: rgb(255 255 255 / 0.1);
-  --thumbnail-selected-color: rgb(255 255 255 / 0.2);
-  --doorhanger-bg-color: #28646e;
-  --doorhanger-border-color: rgb(39 39 43);
-  --doorhanger-hover-color: rgb(249 249 250);
-  --doorhanger-hover-bg-color: #245b64;
-  --doorhanger-separator-color: rgb(92 92 97);
+  --field-bg-color: rgb(255 255 255);
+  --field-border-color: rgb(187 187 188);
+  --treeitem-color: rgb(0 0 0 / 0.8);
+  --treeitem-bg-color: rgb(0 0 0 / 0.15);
+  --treeitem-hover-color: rgb(0 0 0 / 0.9);
+  --treeitem-selected-color: rgb(0 0 0 / 0.9);
+  --treeitem-selected-bg-color: rgb(0 0 0 / 0.25);
+  --thumbnail-hover-color: rgb(0 0 0 / 0.1);
+  --thumbnail-selected-color: rgb(0 0 0 / 0.2);
+  --doorhanger-bg-color: rgb(255 255 255);
+  --doorhanger-border-color: rgb(12 12 13 / 0.2);
+  --doorhanger-hover-color: rgb(12 12 13);
+  --doorhanger-hover-bg-color: rgb(237 237 237);
+  --doorhanger-separator-color: rgb(222 222 222);
   --dialog-button-border: none;
-  --dialog-button-bg-color: rgb(92 92 97);
-  --dialog-button-hover-bg-color: rgb(115 115 115);
+  --dialog-button-bg-color: rgb(12 12 13 / 0.1);
+  --dialog-button-hover-bg-color: rgb(12 12 13 / 0.3);
 
-  --loading-icon: url(images/loading-dark.svg);
+  --loading-icon: url(images/loading.svg);
   --treeitem-expanded-icon: url(images/treeitem-expanded.svg);
   --treeitem-collapsed-icon: url(images/treeitem-collapsed.svg);
   --toolbarButton-editorFreeText-icon: url(images/toolbarButton-editorFreeText.svg);
@@ -137,6 +137,48 @@
   --inline-start: right;
   --inline-end: left;
   /*#endif*/
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --main-color: rgb(170 241 231);
+    --body-bg-color: rgb(40 100 110);
+    --progressBar-color: rgb(80 227 194);
+    --progressBar-bg-color: rgb(74 74 74);
+    --progressBar-blend-color: rgb(170 241 231);
+    --scrollbar-color: rgb(170 241 231);
+    --scrollbar-bg-color: rgb(74 74 74);
+    --toolbar-icon-bg-color: rgb(170 241 231);
+    --toolbar-icon-hover-bg-color: rgb(80 227 194);
+
+    --sidebar-narrow-bg-color: rgb(40, 100, 110 / 0.9);
+    --sidebar-toolbar-bg-color: rgb(74 74 74);
+    --toolbar-bg-color: rgb(74 74 74);
+    --toolbar-border-color: rgb(40 100 110);
+    --button-hover-color: rgb(102 102 103);
+    --toggled-btn-color: rgb(255 255 255);
+    --toggled-btn-bg-color: rgb(0 0 0 / 0.3);
+    --toggled-hover-active-btn-color: rgb(0 0 0 / 0.4);
+    --dropdown-btn-bg-color: rgb(74 74 79);
+    --separator-color: rgb(0 0 0 / 0.3);
+    --field-color: rgb(250 250 250);
+    --field-bg-color: rgb(64 64 68);
+    --field-border-color: rgb(115 115 115);
+    --treeitem-color: rgb(255 255 255 / 0.8);
+    --treeitem-bg-color: rgb(255 255 255 / 0.15);
+    --treeitem-hover-color: rgb(255 255 255 / 0.9);
+    --treeitem-selected-color: rgb(255 255 255 / 0.9);
+    --treeitem-selected-bg-color: rgb(255 255 255 / 0.25);
+    --thumbnail-hover-color: rgb(255 255 255 / 0.1);
+    --thumbnail-selected-color: rgb(255 255 255 / 0.2);
+    --doorhanger-bg-color: rgb(74 74 79);
+    --doorhanger-border-color: rgb(39 39 43);
+    --doorhanger-hover-color: rgb(249 249 250);
+    --doorhanger-hover-bg-color: rgb(93 94 98);
+    --doorhanger-separator-color: rgb(92 92 97);
+    --dialog-button-bg-color: rgb(92 92 97);
+    --dialog-button-hover-bg-color: rgb(115 115 115);
+  }
 }
 
 @media screen and (forced-colors: active) {


### PR DESCRIPTION
Light:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/58c0eb7a-13e7-482a-81eb-883c0a3c9f55" />

Dark:
<img width="331" alt="image" src="https://github.com/user-attachments/assets/b25c3b46-d445-4a22-8849-5beba5e0e19f" />
